### PR TITLE
Make initialization of members standard conform

### DIFF
--- a/src/force.h
+++ b/src/force.h
@@ -18,6 +18,7 @@ namespace STD{
 			}
 		}
 	};
+
 	void CalcPressure(PS::ParticleSystem<STD::RealPtcl>& sph_system){
 		#pragma omp parallel for
 		for(PS::S32 i = 0 ; i < sph_system.getNumberOfParticleLocal() ; ++ i){
@@ -25,6 +26,7 @@ namespace STD{
 			sph_system[i].snds = sph_system[i].EoS->SoundSpeed(sph_system[i].dens, sph_system[i].eng);
 		}
 	}
+
 	class CalcDerivative{
 		kernel_t kernel;
 		public:
@@ -78,8 +80,9 @@ namespace STD{
 			}
 		}
 	};
+
 	template <class TPtclJ> class CalcGravityForce{
-		static const double G = 6.67e-11;
+		static const double G;
 		public:
 		void operator () (const EPI::Grav* const __restrict ep_i, const PS::S32 Nip, const TPtclJ* const __restrict ep_j, const PS::S32 Njp, RESULT::Grav* const grav){
 			for(PS::S32 i = 0; i < Nip ; ++ i){
@@ -96,5 +99,8 @@ namespace STD{
 			}
 		}
 	};
+
+	template <class TPtclJ>
+	const double CalcGravityForce<TPtclJ>::G = 6.67e-11;
 }
 

--- a/src/init/GI.h
+++ b/src/init/GI.h
@@ -5,7 +5,7 @@
 #endif
 template <class Ptcl> class GI : public Problem<Ptcl>{
 	public:
-	static const double END_TIME = 1.0e+4;
+	static const double END_TIME;
 	static void setupIC(PS::ParticleSystem<Ptcl>& sph_system, system_t& sysinfo, PS::DomainInfo& dinfo){
 		const bool createTarget = true;//set false if you make an impactor.
 		const double Corr = .98;//Correction Term
@@ -246,3 +246,5 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
 	}
 };
 
+template <class Ptcl>
+const double GI<Ptcl>::END_TIME = 1.0e+4;


### PR DESCRIPTION
This should make the initialization of the static const members compliant with the c++ standard. An alternative is to use `constexpr` instead of `const` in the class declaration, but that would require a C++11 compiler (not too much of a problem today, but there are still a few older clusters around, which do not have them yet). This makes the code compile for me (gcc 7.3.0). 