### PR TITLE
Add cmakelists file for system independent makefiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+
+MESSAGE(STATUS "====================================================")
+MESSAGE(STATUS "============ Configuring FDPS_SPH ==================")
+MESSAGE(STATUS "====================================================")
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+
+PROJECT(FDPS_SPH)
+
+#Bring the headers, such as Student.h into the project
+INCLUDE_DIRECTORIES(src FDPS/src)
+
+SET(DEFAULT_BUILD_TYPE "Release")
+
+IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+	MESSAGE(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+	SET(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+ENDIF()
+
+SET(CMAKE_CXX_FLAGS "-DPARTICLE_SIMULATOR_THREAD_PARALLEL -fopenmp -DPARTICLE_SIMULATOR_ALL_64BIT_PRECISION -DFAST_COMM_FOR_2ND_EXCHANGE")
+SET(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math -funroll-loops")
+
+
+MESSAGE(STATUS "CMAKE_BUILD_TYPE:        ${CMAKE_BUILD_TYPE}")
+MESSAGE(STATUS "CMAKE_CXX_FLAGS:         ${CMAKE_CXX_FLAGS}")
+MESSAGE(STATUS "CMAKE_CXX_FLAGS_DEBUG:   ${CMAKE_CXX_FLAGS_DEBUG}")
+MESSAGE(STATUS "CMAKE_CXX_FLAGS_RELEASE: ${CMAKE_CXX_FLAGS_RELEASE}")
+
+ADD_EXECUTABLE(sph.out src/main.cpp)

--- a/src/force.h
+++ b/src/force.h
@@ -18,6 +18,7 @@ namespace STD{
 			}
 		}
 	};
+
 	void CalcPressure(PS::ParticleSystem<STD::RealPtcl>& sph_system){
 		#pragma omp parallel for
 		for(PS::S32 i = 0 ; i < sph_system.getNumberOfParticleLocal() ; ++ i){
@@ -25,6 +26,7 @@ namespace STD{
 			sph_system[i].snds = sph_system[i].EoS->SoundSpeed(sph_system[i].dens, sph_system[i].eng);
 		}
 	}
+
 	class CalcDerivative{
 		kernel_t kernel;
 		public:
@@ -78,8 +80,9 @@ namespace STD{
 			}
 		}
 	};
+
 	template <class TPtclJ> class CalcGravityForce{
-		static const double G = 6.67e-11;
+		static const double G;
 		public:
 		void operator () (const EPI::Grav* const __restrict ep_i, const PS::S32 Nip, const TPtclJ* const __restrict ep_j, const PS::S32 Njp, RESULT::Grav* const grav){
 			for(PS::S32 i = 0; i < Nip ; ++ i){
@@ -96,5 +99,8 @@ namespace STD{
 			}
 		}
 	};
+
+	template <class TPtclJ>
+	const double CalcGravityForce<TPtclJ>::G = 6.67e-11;
 }
 

--- a/src/init/GI.h
+++ b/src/init/GI.h
@@ -5,7 +5,7 @@
 #endif
 template <class Ptcl> class GI : public Problem<Ptcl>{
 	public:
-	static const double END_TIME = 1.0e+4;
+	static const double END_TIME;
 	static void setupIC(PS::ParticleSystem<Ptcl>& sph_system, system_t& sysinfo, PS::DomainInfo& dinfo){
 		const bool createTarget = true;//set false if you make an impactor.
 		const double Corr = .98;//Correction Term
@@ -246,3 +246,5 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
 	}
 };
 
+template <class Ptcl>
+const double GI<Ptcl>::END_TIME = 1.0e+4;


### PR DESCRIPTION
This sits on top of #4 and should only be merged afterwards. It adds a CMakeLists file, which is essentially a configuration file for the open-source program cmake (https://cmake.org/). CMake is often used to let software be compiled on very different systems without having to write or modify Makefiles for all of these systems. This is just a very simple start, but it work on my PC (with gcc 7.3.). I have already noticed that the clang 6.0 compiler does not work, but that is something to fix later. In essence, if you are happy with how cmake works, we can discuss if it still necessary to have a Makefile in the src/ directory.

For now, let's just see if cmake makes configuration and compiling simpler. It already offers the advantage that we can switch between a release mode (with all the optimization flags) and a debug mode (easier to debug, but also slower). A next step could be to let it automatically search for FDPS (instead of hardcoding its path in the Makefile).

What do you think, is this something that would be useful?