### PR TITLE
Fixed CloneFDPS.sh

### DIFF
--- a/CloneFDPS.sh
+++ b/CloneFDPS.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 git clone https://github.com/FDPS/FDPS.git
+cd FDPS
 
 # This checks out a version of FDPS that is known to work with FDPS_SPH
 # Modify if you want to use a different FDPS version
 git checkout v5.0c
+cd ..


### PR DESCRIPTION
Changed CloneFDPS.sh to cd into the FDPS directory before checking out the proper version. The script then cd's back up to the original directory.