### PR TITLE
Add TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: cpp
+compiler:
+  - gcc
+script:
+  - ./contrib/ci/ci.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@ MESSAGE(STATUS "====================================================")
 MESSAGE(STATUS "============ Configuring FDPS_SPH ==================")
 MESSAGE(STATUS "====================================================")
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
+
+SET(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 PROJECT(FDPS_SPH)
 

--- a/contrib/ci/ci.sh
+++ b/contrib/ci/ci.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+bash ./CloneFDPS.sh
+mkdir build
+cd build
+cmake ..
+make

--- a/src/EoS.h
+++ b/src/EoS.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sstream>
+
 namespace EoS{
 	//////////////////
 	//abstract class


### PR DESCRIPTION
I would like to add some support for automatic testing to FDPS SPH to prevent us from breaking things accidentally. One common service for this is TravisCI (https://travis-ci.org/), which is very widely used for open source projects, and easy to set up (see how little changes I needed below). To make it work though, we need to set up access for the TravisCI Github App to the FDPS SPH repository. I did that for my personal github repository of FDPS SPH, and you can see how the testing looks like in this example pull request: https://github.com/gassmoeller/FDPS_SPH/pull/1. If you scroll down to the bottom you see the `All checks have passed` Box that contains informations about how the tests went. In this case I even found a bug in the current version of the code that prevented compiling with certain gcc compilers (5.4.0). At the moment Travis will only test if the code compiles, but we can easily extend it to run a small example model and check the results of that model (that would be the second step).
For this to work @NatsukiHosono: could you install the Travis Github App for this repository? It is available here: https://github.com/apps/travis-ci. It will then ask you if you want to activate it for all repositories (probably not), or only for certain repositories. Only FDPS_SPH would be good enough for now.

Do you agree this would be a nice addition? Let me know if you have any questions or concerns about this.