### PR TITLE
Remove hard-coded input directory

### DIFF
--- a/src/GI.h
+++ b/src/GI.h
@@ -21,11 +21,8 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
 		/////////
 
 		// Use parameters from input file, or defaults if none provided
-		// TODO: Currently the input file has to be in the same directory as the executable
-		//       Change this into a command-line parameter.
-        std::string input_directory("input/");
-        ParameterFile parameter_file(input_directory + input_file);
-        std::cout << "reading from input/" << input_file << std::endl;
+        ParameterFile parameter_file(input_file);
+        std::cout << "Reading parameters from " << input_file << std::endl;
 		PS::F64 UnitMass = parameter_file.getValueOf("UnitMass", 6.0e+24);
 		PS::F64 UnitRadi = parameter_file.getValueOf("UnitRadi", 6400e+3);
 		PS::F64 coreFracRadi = parameter_file.getValueOf("coreFracRadi", 3500.0e+3 / 6400.0e+3);


### PR DESCRIPTION
We should not put strict limitations on the names of input directories like `input/`. The user should just specify the full path to the input file on the command line. I checked that this still works with the input files in input/....