### PR TITLE
Restore default behavior

### DIFF
--- a/src/GI.h
+++ b/src/GI.h
@@ -31,7 +31,7 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
 		PS::F64 coreFracRadi = parameter_file.getValueOf("coreFracRadi", 3500.0e+3 / 6400.0e+3);
 		PS::F64 coreFracMass = parameter_file.getValueOf("coreFracMass", 0.3);
 		PS::F64 imptarMassRatio = parameter_file.getValueOf("imptarMassRatio", 0.1);
-        int mode = parameter_file.getValueOf("mode", 1 );
+        int mode = parameter_file.getValueOf("mode", 2 );
         PS::F64 impVel = parameter_file.getValueOf("impVel",0.);
         end_time = parameter_file.getValueOf("end_time",1.0e+4);
         damping = parameter_file.getValueOf("damping",1.);


### PR DESCRIPTION
When merging #19 we accidentally changed the default behavior of the code. Instead of only creating a target from known positions we now required data files to run if no mode was specified. I think we should keep the default at a value that does not require to create some data files first. Also this change breaks the example file `examples/input.txt`. The mode 2 should be the behavior from before (only create a target).