### PR TITLE
Choose old default name for output directory

### DIFF
--- a/src/io.h
+++ b/src/io.h
@@ -8,7 +8,7 @@ template <class ThisPtcl> void OutputBinary(PS::ParticleSystem<ThisPtcl>& sph_sy
 	//Binary
 	char filename[256];
 	std::ofstream fout;
-    sprintf(filename, "results/%s/%05d_%05d.bin", out_dir, PS::Comm::getNumberOfProc(), PS::Comm::getRank());
+    sprintf(filename, "%s/%05d_%05d.bin", out_dir.c_str(), PS::Comm::getNumberOfProc(), PS::Comm::getRank());
 	fout.open(filename, std::ios::out | std::ios::binary | std::ios::trunc);
 	if(!fout){
 		std::cout << "cannot write restart file." << std::endl;
@@ -27,12 +27,14 @@ template <class ThisPtcl> void OutputFileWithTimeInterval(PS::ParticleSystem<Thi
 		FileHeader header;
 		header.time = sysinfo.time;
 		header.Nbody = sph_system.getNumberOfParticleLocal();
-		char filename[256];
-        sprintf(filename, "results/%s/%05d", out_dir, sysinfo.output_id);
-		sph_system.writeParticleAscii(filename, "%s_%05d_%05d.dat", header);
+		char filename[20];
+        sprintf(filename, "results.%05d", sysinfo.output_id);
+		std::string full_filename = out_dir + filename;
+
+		sph_system.writeParticleAscii(full_filename.c_str(), "%s_%05d_%05d.dat", header);
 		if(PS::Comm::getRank() == 0){
             std::cout << "//================================" << std::endl;
-            std::cout << "output " << filename << "." << std::endl;
+            std::cout << "output " << full_filename << "." << std::endl;
 			std::cout << "//================================" << std::endl;
 		}
 		sysinfo.output_time += end_time / PARAM::NUMBER_OF_SNAPSHOTS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,9 +38,7 @@ int main(int argc, char* argv[]){
 	//////////////////
     bool newSim = true;
     std::string input_file("input.txt");
-    std::string output_directory("default");
-
-	createOutputDirectory("result");
+    std::string output_directory("result/");
 
     for (int i=0; i<argc; i++) {
         if (strcmp(argv[i],"-i")==0 || strcmp(argv[i], "--input")==0) {
@@ -48,6 +46,8 @@ int main(int argc, char* argv[]){
         }
         if (strcmp(argv[i],"-o")==0 || strcmp(argv[i], "--output")==0) {
         	output_directory = std::string(argv[i+1]);
+        	if (output_directory.back() != '/')
+        		output_directory += '/';
         }
         if (strcmp(argv[i],"-r")==0 || strcmp(argv[i], "--resume")==0) {
             sysinfo.step = atoi(argv[i+1]);
@@ -55,6 +55,8 @@ int main(int argc, char* argv[]){
         }
     }
     
+	createOutputDirectory(output_directory);
+
     if (newSim) {
         PROBLEM::setupIC(sph_system, sysinfo, dinfo, input_file);
         PROBLEM::setEoS(sph_system);


### PR DESCRIPTION
This reverts the default name of the output directory back to `result`, and it also fixes a number of bugs I accidentally introduced in #19 (like handing over a c++ string to a function that expected a c-string).