### PR TITLE
Output directory is now set from input file, not runtime option

### DIFF
--- a/input/imp.txt
+++ b/input/imp.txt
@@ -16,3 +16,4 @@ mode = 3                    # imp on only, creates imp.dat
     imptarMassRatio = 0.2   # impator-to-target mass ratio
 
 end_time = 1.0e+5           # number of seconds in the simulation
+output_directory = results/imp

--- a/input/tar.txt
+++ b/input/tar.txt
@@ -18,3 +18,4 @@ mode = 2                    # tar on only, creates tar.dat
 end_time = 1.0e+5           # number of seconds in the simulation
 
 damping = 0.8
+output_directory = results/tar-test/

--- a/src/GI.h
+++ b/src/GI.h
@@ -9,6 +9,7 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
     public:
 	static double end_time;
     static double damping;
+    static std::string output_directory;
 	static void setupIC(PS::ParticleSystem<Ptcl>& sph_system, system_t& sysinfo, PS::DomainInfo& dinfo,
                         const std::string &input_file){
 		const double Corr = .98;//Correction Term
@@ -32,7 +33,10 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
         PS::F64 impVel = parameter_file.getValueOf("impVel",0.);
         end_time = parameter_file.getValueOf("end_time",1.0e+4);
         damping = parameter_file.getValueOf("damping",1.);
-        
+	output_directory = parameter_file.getValueOf("output_directory",std::string("results/"));
+        if (output_directory.back() != '/')
+            output_directory += '/';
+
 		const PS::F64 Expand = 1.1;
 		const PS::F64 tarMass = UnitMass;
 		const PS::F64 tarRadi = UnitRadi;

--- a/src/GI.h
+++ b/src/GI.h
@@ -11,7 +11,7 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
     static double damping;
     static std::string output_directory;
 	static void setupIC(PS::ParticleSystem<Ptcl>& sph_system, system_t& sysinfo, PS::DomainInfo& dinfo,
-                        const std::string &input_file){
+                        ParameterFile &parameter_file){
 		const double Corr = .98;//Correction Term
 		/////////
 		//place ptcls
@@ -22,8 +22,8 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
 		/////////
 
 		// Use parameters from input file, or defaults if none provided
-        ParameterFile parameter_file(input_file);
-        std::cout << "Reading parameters from " << input_file << std::endl;
+//        ParameterFile parameter_file(input_file);
+        //std::cout << "Reading parameters from " << input_file << std::endl;
 		PS::F64 UnitMass = parameter_file.getValueOf("UnitMass", 6.0e+24);
 		PS::F64 UnitRadi = parameter_file.getValueOf("UnitRadi", 6400e+3);
 		PS::F64 coreFracRadi = parameter_file.getValueOf("coreFracRadi", 3500.0e+3 / 6400.0e+3);
@@ -33,9 +33,9 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
         PS::F64 impVel = parameter_file.getValueOf("impVel",0.);
         end_time = parameter_file.getValueOf("end_time",1.0e+4);
         damping = parameter_file.getValueOf("damping",1.);
-	output_directory = parameter_file.getValueOf("output_directory",std::string("results/"));
-        if (output_directory.back() != '/')
-            output_directory += '/';
+	//output_directory = parameter_file.getValueOf("output_directory",std::string("results/"));
+       // if (output_directory.back() != '/')
+            //output_directory += '/';
 
 		const PS::F64 Expand = 1.1;
 		const PS::F64 tarMass = UnitMass;

--- a/src/GI.h
+++ b/src/GI.h
@@ -9,7 +9,6 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
     public:
 	static double end_time;
     static double damping;
-    static std::string output_directory;
 	static void setupIC(PS::ParticleSystem<Ptcl>& sph_system, system_t& sysinfo, PS::DomainInfo& dinfo,
                         ParameterFile &parameter_file){
 		const double Corr = .98;//Correction Term

--- a/src/GI.h
+++ b/src/GI.h
@@ -30,8 +30,8 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
         PS::F64 impVel = parameter_file.getValueOf("impVel",0.);
         end_time = parameter_file.getValueOf("end_time",1.0e+4);
         damping = parameter_file.getValueOf("damping",1.);
-		
-        const PS::F64 Expand = 1.1;
+        
+		const PS::F64 Expand = 1.1;
 		const PS::F64 tarMass = UnitMass;
 		const PS::F64 tarRadi = UnitRadi;
 		const PS::F64 tarCoreMass = tarMass * coreFracMass;

--- a/src/GI.h
+++ b/src/GI.h
@@ -22,8 +22,6 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
 		/////////
 
 		// Use parameters from input file, or defaults if none provided
-//        ParameterFile parameter_file(input_file);
-        //std::cout << "Reading parameters from " << input_file << std::endl;
 		PS::F64 UnitMass = parameter_file.getValueOf("UnitMass", 6.0e+24);
 		PS::F64 UnitRadi = parameter_file.getValueOf("UnitRadi", 6400e+3);
 		PS::F64 coreFracRadi = parameter_file.getValueOf("coreFracRadi", 3500.0e+3 / 6400.0e+3);
@@ -33,11 +31,8 @@ template <class Ptcl> class GI : public Problem<Ptcl>{
         PS::F64 impVel = parameter_file.getValueOf("impVel",0.);
         end_time = parameter_file.getValueOf("end_time",1.0e+4);
         damping = parameter_file.getValueOf("damping",1.);
-	//output_directory = parameter_file.getValueOf("output_directory",std::string("results/"));
-       // if (output_directory.back() != '/')
-            //output_directory += '/';
-
-		const PS::F64 Expand = 1.1;
+		
+        const PS::F64 Expand = 1.1;
 		const PS::F64 tarMass = UnitMass;
 		const PS::F64 tarRadi = UnitRadi;
 		const PS::F64 tarCoreMass = tarMass * coreFracMass;

--- a/src/io.h
+++ b/src/io.h
@@ -78,7 +78,7 @@ template <class ThisPtcl> void InputBinary(PS::ParticleSystem<ThisPtcl>& sph_sys
 }
 
 void createOutputDirectory(const std::string &directory_name){
-	// check if the output directory exists, if not create it.
+    // check if the output directory exists, if not create it.
 	if (DIR *output_directory = opendir(directory_name.c_str())){
 		int error = closedir(output_directory);
 		assert(error == 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@
 
 template <class Ptcl> double GI<Ptcl>::end_time;
 template <class Ptcl> double GI<Ptcl>::damping;
-//template <class Ptcl> std::string GI<Ptcl>::output_directory;
 
 int main(int argc, char* argv[]){
 	namespace PTCL = STD;
@@ -63,6 +62,7 @@ int main(int argc, char* argv[]){
         InputFileWithTimeInterval<PTCL::RealPtcl>(sph_system, sysinfo);
         PROBLEM::setEoS(sph_system);
     }
+
 	#pragma omp parallel for
 	for(PS::S32 i = 0 ; i < sph_system.getNumberOfParticleLocal() ; ++ i){
 		sph_system[i].initialize();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 
 template <class Ptcl> double GI<Ptcl>::end_time;
 template <class Ptcl> double GI<Ptcl>::damping;
+template <class Ptcl> std::string GI<Ptcl>::output_directory;
 
 int main(int argc, char* argv[]){
 	namespace PTCL = STD;
@@ -38,24 +39,16 @@ int main(int argc, char* argv[]){
 	//////////////////
     bool newSim = true;
     std::string input_file("input.txt");
-    std::string output_directory("result/");
 
     for (int i=0; i<argc; i++) {
         if (strcmp(argv[i],"-i")==0 || strcmp(argv[i], "--input")==0) {
         	input_file = std::string(argv[i+1]);
-        }
-        if (strcmp(argv[i],"-o")==0 || strcmp(argv[i], "--output")==0) {
-        	output_directory = std::string(argv[i+1]);
-        	if (output_directory.back() != '/')
-        		output_directory += '/';
         }
         if (strcmp(argv[i],"-r")==0 || strcmp(argv[i], "--resume")==0) {
             sysinfo.step = atoi(argv[i+1]);
             newSim = false;
         }
     }
-    
-	createOutputDirectory(output_directory);
 
     if (newSim) {
         PROBLEM::setupIC(sph_system, sysinfo, dinfo, input_file);
@@ -66,11 +59,13 @@ int main(int argc, char* argv[]){
         PROBLEM::setEoS(sph_system);
     }
     
+	createOutputDirectory(PROBLEM::output_directory);
+
 	#pragma omp parallel for
 	for(PS::S32 i = 0 ; i < sph_system.getNumberOfParticleLocal() ; ++ i){
 		sph_system[i].initialize();
 	}
-    OutputFileWithTimeInterval(sph_system, sysinfo, PROBLEM::end_time, output_directory);
+    OutputFileWithTimeInterval(sph_system, sysinfo, PROBLEM::end_time, PROBLEM::output_directory);
 
 	//Dom. info
 	dinfo.decomposeDomainAll(sph_system);
@@ -101,7 +96,7 @@ int main(int argc, char* argv[]){
 	#endif
 	sysinfo.dt = getTimeStepGlobal<PTCL::RealPtcl>(sph_system);
 	PROBLEM::addExternalForce(sph_system, sysinfo);
-	OutputFileWithTimeInterval(sph_system, sysinfo, PROBLEM::end_time, output_directory);
+	OutputFileWithTimeInterval(sph_system, sysinfo, PROBLEM::end_time, PROBLEM::output_directory);
 
 	if(PS::Comm::getRank() == 0){
 		std::cout << "//================================" << std::endl;
@@ -140,7 +135,7 @@ int main(int argc, char* argv[]){
 		}
 		PROBLEM::postTimestepProcess(sph_system, sysinfo);
 		sysinfo.dt = getTimeStepGlobal<PTCL::RealPtcl>(sph_system);
-		OutputFileWithTimeInterval<PTCL::RealPtcl>(sph_system, sysinfo, PROBLEM::end_time, output_directory);
+		OutputFileWithTimeInterval<PTCL::RealPtcl>(sph_system, sysinfo, PROBLEM::end_time, PROBLEM::output_directory);
 		++ sysinfo.step;
 		if(PS::Comm::getRank() == 0){
 			std::cout << "//================================" << std::endl;
@@ -149,7 +144,7 @@ int main(int argc, char* argv[]){
 			std::cout << "//================================" << std::endl;
 		}
 		if(sysinfo.step % 30 == 0){
-			OutputBinary(sph_system, sysinfo, output_directory);
+			OutputBinary(sph_system, sysinfo, PROBLEM::output_directory);
 		}
 	}
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -95,6 +95,7 @@ class ParameterFile{
 			std::cout << "Parameter <" << key << "> not found and no default value provided. Aborting." << std::endl;
 			throw;
 		}
+
 		return parameter_value;
 	  }
 };

--- a/src/parse.h
+++ b/src/parse.h
@@ -95,7 +95,6 @@ class ParameterFile{
 			std::cout << "Parameter <" << key << "> not found and no default value provided. Aborting." << std::endl;
 			throw;
 		}
-
 		return parameter_value;
 	  }
 };


### PR DESCRIPTION
This post responds to a task on our Task list "specify the output directory name from the input file". It removes the ability to specify the output directory at run time using the `-o` / `--output` option. Instead, the user should add a line to their input file similar to:
`output_directory = path/to/directory/`