### PR TITLE
Time Between Data Output

### DIFF
--- a/input/imp.txt
+++ b/input/imp.txt
@@ -16,3 +16,5 @@ mode = 3                    # imp on only, creates imp.dat
     imptarMassRatio = 0.2   # impator-to-target mass ratio
 
 end_time = 1.0e+5           # number of seconds in the simulation
+damping = 1
+output_interval = 100

--- a/input/tar.txt
+++ b/input/tar.txt
@@ -17,4 +17,6 @@ mode = 2                    # tar on only, creates tar.dat
 
 end_time = 1.0e+5           # number of seconds in the simulation
 
-damping = 0.8
+damping = 1
+
+output_interval = 10

--- a/src/io.h
+++ b/src/io.h
@@ -22,7 +22,7 @@ template <class ThisPtcl> void OutputBinary(PS::ParticleSystem<ThisPtcl>& sph_sy
 	fout.close();
 }
 
-template <class ThisPtcl> void OutputFileWithTimeInterval(PS::ParticleSystem<ThisPtcl>& sph_system, system_t& sysinfo, const PS::F64 end_time, std::string &out_dir){
+template <class ThisPtcl> void OutputFileWithTimeInterval(PS::ParticleSystem<ThisPtcl>& sph_system, system_t& sysinfo, const PS::F64 output_interval, std::string &out_dir){
 	if(sysinfo.time > sysinfo.output_time){
 		FileHeader header;
 		header.time = sysinfo.time;
@@ -37,7 +37,7 @@ template <class ThisPtcl> void OutputFileWithTimeInterval(PS::ParticleSystem<Thi
             std::cout << "output " << full_filename << "." << std::endl;
 			std::cout << "//================================" << std::endl;
 		}
-		sysinfo.output_time += end_time / PARAM::NUMBER_OF_SNAPSHOTS;
+        sysinfo.output_time += output_interval;
 		++ sysinfo.output_id;
 	}
 }

--- a/src/io.h
+++ b/src/io.h
@@ -37,7 +37,7 @@ template <class ThisPtcl> void OutputFileWithTimeInterval(PS::ParticleSystem<Thi
             std::cout << "output " << full_filename << "." << std::endl;
 			std::cout << "//================================" << std::endl;
 		}
-        sysinfo.output_time += output_interval;
+		sysinfo.output_time += output_interval;
 		++ sysinfo.output_id;
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]){
         InputFileWithTimeInterval<PTCL::RealPtcl>(sph_system, sysinfo);
         PROBLEM::setEoS(sph_system);
     }
-    PS::F64 output_interval = parameter_file.getValueOf("output_interval",100.);
+    PS::F64 output_interval = parameter_file.getValueOf("output_interval",50.);
 
 	#pragma omp parallel for
 	for(PS::S32 i = 0 ; i < sph_system.getNumberOfParticleLocal() ; ++ i){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]){
 	//////////////////
     bool newSim = true;
     std::string input_file("input.txt");
-    std::string output_directory("result/");
+    std::string output_directory("results/");
 
     for (int i=0; i<argc; i++) {
         if (strcmp(argv[i],"-i")==0 || strcmp(argv[i], "--input")==0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]){
             newSim = false;
         }
     }
-    
+    ParameterFile parameter_file(input_file);
 	createOutputDirectory(output_directory);
 
     if (newSim) {
@@ -65,12 +65,12 @@ int main(int argc, char* argv[]){
         InputFileWithTimeInterval<PTCL::RealPtcl>(sph_system, sysinfo);
         PROBLEM::setEoS(sph_system);
     }
-    
+    PS::F64 output_interval = parameter_file.getValueOf("output_interval",100.);
 	#pragma omp parallel for
 	for(PS::S32 i = 0 ; i < sph_system.getNumberOfParticleLocal() ; ++ i){
 		sph_system[i].initialize();
 	}
-    OutputFileWithTimeInterval(sph_system, sysinfo, PROBLEM::end_time, output_directory);
+    OutputFileWithTimeInterval(sph_system, sysinfo, output_interval, output_directory);
 
 	//Dom. info
 	dinfo.decomposeDomainAll(sph_system);
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]){
 	#endif
 	sysinfo.dt = getTimeStepGlobal<PTCL::RealPtcl>(sph_system);
 	PROBLEM::addExternalForce(sph_system, sysinfo);
-	OutputFileWithTimeInterval(sph_system, sysinfo, PROBLEM::end_time, output_directory);
+	OutputFileWithTimeInterval(sph_system, sysinfo, output_interval, output_directory);
 
 	if(PS::Comm::getRank() == 0){
 		std::cout << "//================================" << std::endl;
@@ -140,7 +140,7 @@ int main(int argc, char* argv[]){
 		}
 		PROBLEM::postTimestepProcess(sph_system, sysinfo);
 		sysinfo.dt = getTimeStepGlobal<PTCL::RealPtcl>(sph_system);
-		OutputFileWithTimeInterval<PTCL::RealPtcl>(sph_system, sysinfo, PROBLEM::end_time, output_directory);
+		OutputFileWithTimeInterval<PTCL::RealPtcl>(sph_system, sysinfo, output_interval, output_directory);
 		++ sysinfo.step;
 		if(PS::Comm::getRank() == 0){
 			std::cout << "//================================" << std::endl;

--- a/src/param.h
+++ b/src/param.h
@@ -8,8 +8,6 @@ namespace PARAM{
 	#endif
 	const PS::F64 SMTH = 1.2;
 	const PS::F64 C_CFL = 0.3;
-	const PS::U64 NUMBER_OF_SNAPSHOTS = 200;
-	//
 	const PS::U64 NUMBER_OF_DENSITY_SMOOTHING_LENGTH_LOOP = 3;
 	//Balsara (1995)'s switch
 	const bool FLAG_B95  = true;


### PR DESCRIPTION
This is a feature requested on the Projects tab. Now, instead of creating a set number of snapshots equally spaced between sim start and end_time, it instead takes snapshots at a set time interval, so we should be able to make better animations with them.

I also fixed a bug. I know it's not a good idea to do more than one thing in a pull request, but I'm not sure how to undo this fix so I can fix it in another branch. Does anyone have any thoughts on this?