### PR TITLE
Improve some error messages and warnings

### DIFF
--- a/src/EoS.h
+++ b/src/EoS.h
@@ -163,11 +163,14 @@ namespace EoS{
 		 * TODO fill in format description, check that my implementation is correct
 		 */
 		ANEOS(const std::string &filename){
+
+			std::cout << "Reading ANEOS parameters from " << filename << std::endl;
+
 			std::ifstream input;
 			input.open(filename, std::ios::in);
-			if(input.fail() == true){
-				std::cout << "Cannot open file..." << filename << std::endl;
-				return;
+			if(!input.is_open()){
+				std::cout << "Cannot open ANEOS file " << filename << std::endl;
+				throw;
 			}
 
 			const unsigned int n_expected_fields = 5;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,9 +48,10 @@ int main(int argc, char* argv[]){
             newSim = false;
         }
     }
-    ParameterFile parameter_file(input_file);
     std::cout << "Reading parameters from " << input_file << std::endl;
-    std::string output_directory = parameter_file.getValueOf("output_directory",std::string("results/"));
+    ParameterFile parameter_file(input_file);
+
+    std::string output_directory = parameter_file.getValueOf<std::string>("output_directory",std::string("results/"));
     if (output_directory.back() != '/')
         output_directory.back() += '/';
     createOutputDirectory(output_directory);

--- a/src/parse.h
+++ b/src/parse.h
@@ -46,7 +46,7 @@ class ParameterFile{
 		std::ifstream input;
 		input.open(file, std::ios::in);
 		if(input.fail() == true){
-			std::cout << "Cannot open file, assuming default values ..." << std::endl;
+			std::cout << "Cannot open input file, assuming default values ..." << std::endl;
 			return;
 		}
 		std::string line;
@@ -90,10 +90,6 @@ class ParameterFile{
 		      std::cout << "Convert error: cannot convert string '" << param[key] << "' to value" << std::endl;
 		      throw;
 		    }
-		}
-		else{
-			std::cout << "Parameter <" << key << "> not found and no default value provided. Aborting." << std::endl;
-			throw;
 		}
 
 		return parameter_value;


### PR DESCRIPTION
All but the last part of this PR simply rewords warnings or error messages, or reorders them on the screen (so that it reads: `reading file ... error reading file` instead of `error reading file ... reading file`).

The last part was a leftover from #27. We now require a parameter to have a default value, but the function was still assuming that if the parameter is not in the input file it should crash. Instead it should just return the default value.